### PR TITLE
feat: Initial setup for 'Snippets' Chrome DevTools extension

### DIFF
--- a/public/devtools_panel.ts
+++ b/public/devtools_panel.ts
@@ -1,0 +1,9 @@
+chrome.devtools.panels.create(
+  "Snippets", // Title of the panel
+  "", // Icon path (optional, leave empty for now)
+  "public/devtools.html", // HTML page to load in the panel
+  (panel) => {
+    // Optional callback function
+    console.log("Snippets panel created", panel);
+  }
+);


### PR DESCRIPTION
This commit introduces the foundational setup for the 'Snippets' Chrome extension, designed to be used within the DevTools panel.

Key features implemented:
- Vite-based React project initialization.
- Tailwind CSS integration for styling.
- A 'HomePage' React component displaying the title "Snippets" and subtext "start testing your code here".
- Configuration of `manifest.json` for a v3 Chrome extension, including the `devtools_page` setup.
- `devtools_panel.ts` script to create the "Snippets" panel in DevTools, loading `public/devtools.html`.
- `public/devtools.html` as the entry point for the DevTools panel's UI, which loads the React application.
- Updated `vite.config.ts` to handle multiple HTML entry points (`index.html` and `public/devtools.html`), ensuring both are correctly processed and included in the build output.
- The build process (`yarn build`) generates the necessary files in the `dist` directory, ready for loading as an unpacked extension.

The root `index.html` has been simplified to a placeholder, as the primary functionality resides in the DevTools panel. Placeholder icons are used for the extension.